### PR TITLE
Speed up tests and prevent them from timing out

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Richard Walker <richard.walker@finn.no>",
   "license": "MIT",
   "dependencies": {
+    "lolex": "^2.7.0",
     "readable-stream": "^2.3.5",
     "time-span": "^2.0.0"
   },


### PR DESCRIPTION
## Status
**READY**

## Description
Replaces a promisified setTimeout with lolex for mainpulating timing. This speeds up running the tests from ~3s to ~500ms. 

## Todos
- [ ] Tests
- [ ] Documentation

## Related PRs
* None