### PR TITLE
Drop event

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,3 +246,18 @@ const end = client.timer(options);
 // ... thing to be measured
 end(options);
 ```
+
+### instance events
+
+#### drop
+
+Emitted when the client starts dropping metrics. Will emit the dropped metric.
+
+_Example_
+
+```js
+const client = new Metrics();
+client.on('drop', metric => {
+    console.log('dropped metric', metric);
+});
+```

--- a/lib/client.js
+++ b/lib/client.js
@@ -24,7 +24,8 @@ module.exports = class Metrics extends PassThrough {
             this._readableState.buffer.length >
             this._readableState.highWaterMark
         ) {
-            this.read();
+            const metric = this.read();
+            this.emit('drop', metric);
         }
     }
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -152,7 +152,7 @@ test('client.metric() - max buffer is respected', () => {
 test('client.metric() - max buffer is reached - should emit drop event', () => {
     const dropped = [];
     const client = new MetricsClient();
-    client.on('drop', (metric) => {
+    client.on('drop', metric => {
         dropped.push(metric);
     });
 


### PR DESCRIPTION
## Status
**READY**

## Description
Added a `drop` event which will fire when the client starts dropping metrics from the stream buffer for some reason. Emits the dropped metric.

```js
const client = new Metrics();
client.on('drop', metric => {
    console.log('dropped metric', metric);
});
```

## Todos
- [x] Tests
- [x] Documentation

## Related PRs
* None