### PR TITLE
Harden empty check

### DIFF
--- a/lib/metric.js
+++ b/lib/metric.js
@@ -4,6 +4,7 @@ const util = require('util');
 
 const metric = Symbol('metric');
 const source = Symbol('source');
+const notEmpty = Symbol('empty');
 
 module.exports = class Metric {
     constructor(metricObj) {
@@ -32,11 +33,11 @@ module.exports = class Metric {
     }
 
     get value() {
-        return this[metric].value || null;
+        return this[notEmpty](this[metric].value) ? this[metric].value : null;
     }
 
     get time() {
-        return this[metric].time || null;
+        return this[notEmpty](this[metric].time) ? this[metric].time : null;
     }
 
     get meta() {
@@ -67,5 +68,21 @@ module.exports = class Metric {
 
     get [Symbol.toStringTag]() {
         return 'Metric';
+    }
+
+    [notEmpty](value) {
+        if (value === undefined) {
+            return false;
+        }
+
+        if (value === null) {
+            return false;
+        }
+
+        if (typeof value === 'string' && value.trim().length === 0) {
+            return false;
+        }
+
+        return true;
     }
 };

--- a/test/metric.js
+++ b/test/metric.js
@@ -46,7 +46,7 @@ tap.test('stringifying includes all keys', t => {
     t.end();
 });
 
-tap.test('omitting required keys results in undefined instead of null', t => {
+tap.test('omitting required keys results in undefined instead of "null"', t => {
     const metric = new Metric({
         name: 'valid_name',
     });
@@ -58,6 +58,38 @@ tap.test('omitting required keys results in undefined instead of null', t => {
     t.same(metric.meta, {});
     t.end();
 });
+
+tap.test('the number 0 is treated as a number and does not yeld "null"', t => {
+    const metric = new Metric({
+        name: 'valid_name',
+        value: 0,
+        timestamp: 0,
+    });
+    t.equal(metric.timestamp, 0);
+    t.equal(metric.value, 0);
+    t.end();
+});
+
+tap.test('empty string value is treated as "null"', t => {
+    const metric = new Metric({
+        name: 'valid_name',
+        value: '',
+    });
+    t.equal(metric.value, null);
+    t.end();
+});
+
+tap.test(
+    'empty string value, consist of multiple whitespaces, is treated as "null"',
+    t => {
+        const metric = new Metric({
+            name: 'valid_name',
+            value: '   ',
+        });
+        t.equal(metric.value, null);
+        t.end();
+    },
+);
 
 tap.test('util.inspect includes all keys', t => {
     const metric = new Metric({


### PR DESCRIPTION
## Status
**READY**

## Description
In cases where `value` is the numner `0`, the empty check will actually yeld `null`. This PR hardens our empty check to check for explisit empty values.

## Todos
- [x] Tests
- [x] Documentation

## Related PRs
* None