### PR TITLE
Remove redundant (and wrongly) set of source property

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -15,7 +15,7 @@ const Histogram = require('./histogram');
 const push = Symbol('push');
 
 const MetricsClient = class MetricsClient extends stream.Transform {
-    constructor({ id = undefined } = {}) {
+    constructor({ id } = {}) {
         super(
             Object.assign(
                 {
@@ -49,8 +49,6 @@ const MetricsClient = class MetricsClient extends stream.Transform {
     counter(options) {
         const counter = new Counter(options);
         counter.on('metric', metric => {
-            // eslint-disable-next-line no-param-reassign
-            metric.source = this.source;
             this[push](metric);
         });
         return counter;
@@ -59,8 +57,6 @@ const MetricsClient = class MetricsClient extends stream.Transform {
     gauge(options) {
         const gauge = new Gauge(options);
         gauge.on('metric', metric => {
-            // eslint-disable-next-line no-param-reassign
-            metric.source = this.source;
             this[push](metric);
         });
         return gauge;
@@ -69,8 +65,6 @@ const MetricsClient = class MetricsClient extends stream.Transform {
     summary(options) {
         const summary = new Summary(options);
         summary.on('metric', metric => {
-            // eslint-disable-next-line no-param-reassign
-            metric.source = this.source;
             this[push](metric);
         });
         return summary;
@@ -79,8 +73,6 @@ const MetricsClient = class MetricsClient extends stream.Transform {
     histogram(options) {
         const histogram = new Histogram(options);
         histogram.on('metric', metric => {
-            // eslint-disable-next-line no-param-reassign
-            metric.source = this.source;
             this[push](metric);
         });
         return histogram;
@@ -98,14 +90,12 @@ const MetricsClient = class MetricsClient extends stream.Transform {
                 ...opts,
                 meta,
             });
-            metric.source = this.source;
             this[push](metric);
         };
     }
 
     metric(options) {
         const metric = new Metric(options);
-        metric.source = this.source;
         this[push](metric);
     }
 


### PR DESCRIPTION
Setting `.source` on the metric object is done in the `.push()` method so no need to do so for each metric type.