### PR TITLE
Add type definitions for the client and fix some stuff in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ class Consumer extends Writable {
         let url;
         let method;
 
-        metric.labels.forEach(obj => {
+        metric.labels.forEach((obj) => {
             if (obj.name === 'url') {
                 url = obj.value;
             }
@@ -315,12 +315,12 @@ Creates an instance of a `Histogram` class which can be used to populate the met
 
 **options**
 
-| name          | description                                   | type     | default | required |
-| ------------- | --------------------------------------------- | -------- | ------- | -------- |
-| `name`        | Metric name. valid characters: a-z,A-Z,0-9,\_ | `string` | null    | `true`   |
-| `description` | Metric description                            | `string` | null    | `true`   |
-| `meta`        | Available to be used to hold any misc data.   | `object` | null    | `false`  |
-| `labels`      | Available to be used to hold label data.      | `object` | null    | `false`  |
+| name          | description                                   | type       | default | required |
+| ------------- | --------------------------------------------- | ---------- | ------- | -------- |
+| `name`        | Metric name. valid characters: a-z,A-Z,0-9,\_ | `string`   | null    | `true`   |
+| `description` | Metric description                            | `string`   | null    | `true`   |
+| `buckets`     | Set custom buckets                            | `number[]` | null    | `false`  |
+| `labels`      | Available to be used to hold label data.      | `object`   | null    | `false`  |
 
 _Example_
 
@@ -333,10 +333,10 @@ const histogram = client.histogram(options);
 
 Method that when called will populate the metrics stream with a histogram value.
 
-| name      | description                                        | type      | default | required |
-| --------- | -------------------------------------------------- | --------- | ------- | -------- |
-| `value`   | Value to set the gauge to                          | `integer` | null    | `true`   |
-| `options` | Object that can be used to specify labels and meta | `object`  | `{}`    | `false`  |
+| name      | description                                           | type      | default | required |
+| --------- | ----------------------------------------------------- | --------- | ------- | -------- |
+| `value`   | Value to set the gauge to                             | `integer` | null    | `true`   |
+| `options` | Object that can be used to specify labels and buckets | `object`  | `{}`    | `false`  |
 
 _Example_
 
@@ -345,18 +345,19 @@ const histogram = client.histogram(options);
 
 histogram.observe(0.001); // observe value 0.001
 histogram.observe(5, { labels: { url: 'http://finn.no' } }); // observe value 5, specify labels
-histogram.observe(0.01, {
-    meta: { buckets: [0.0001, 0.001, 0.01, 0.1, 0.5, 1, 10, 100] }, // observe 0.01, use meta to specify bucket options
-});
+histogram.observe(
+    0.01,
+    { buckets: [0.0001, 0.001, 0.01, 0.1, 0.5, 1, 10, 100] }, // observe 0.01, set buckets
+);
 ```
 
 ##### histogram.timer(options)
 
 Method that when called will return an end function for use in measuring the time between 2 points
 
-| name      | description                                        | type     | default | required |
-| --------- | -------------------------------------------------- | -------- | ------- | -------- |
-| `options` | Object that can be used to specify labels and meta | `object` | `{}`    | `false`  |
+| name      | description                                           | type     | default | required |
+| --------- | ----------------------------------------------------- | -------- | ------- | -------- |
+| `options` | Object that can be used to specify labels and buckets | `object` | `{}`    | `false`  |
 
 _Examples_
 
@@ -381,7 +382,9 @@ end({ labels: { url: 'http://finn.no' } }); // set labels in end function
 ```
 
 ```js
-const end = histogram.timer(meta: { buckets: [0.0001, 0.001, 0.01, 0.1, 0.5, 1, 10, 100] }); // start timer, set meta
+const end = histogram.timer({
+    buckets: [0.0001, 0.001, 0.01, 0.1, 0.5, 1, 10, 100],
+}); // start timer, set buckets
 // stuff happens
 end();
 ```
@@ -392,12 +395,12 @@ Creates an instance of a `Summary` class which can be used to populate the metri
 
 **options**
 
-| name          | description                                   | type     | default | required |
-| ------------- | --------------------------------------------- | -------- | ------- | -------- |
-| `name`        | Metric name. valid characters: a-z,A-Z,0-9,\_ | `string` | null    | `true`   |
-| `description` | Metric description                            | `string` | null    | `true`   |
-| `meta`        | Available to be used to hold any misc data.   | `object` | null    | `false`  |
-| `labels`      | Available to be used to hold label data.      | `object` | null    | `false`  |
+| name          | description                                   | type       | default | required |
+| ------------- | --------------------------------------------- | ---------- | ------- | -------- |
+| `name`        | Metric name. valid characters: a-z,A-Z,0-9,\_ | `string`   | null    | `true`   |
+| `description` | Metric description                            | `string`   | null    | `true`   |
+| `quantiles`   | Set custom quantiles                          | `number[]` | null    | `false`  |
+| `labels`      | Available to be used to hold label data.      | `object`   | null    | `false`  |
 
 _Example_
 
@@ -410,10 +413,10 @@ const summary = client.summary(options);
 
 Method that when called will populate the metrics stream with a summary value.
 
-| name      | description                                        | type      | default | required |
-| --------- | -------------------------------------------------- | --------- | ------- | -------- |
-| `value`   | Value to set the summary to                        | `integer` | null    | `true`   |
-| `options` | Object that can be used to specify labels and meta | `object`  | `{}`    | `false`  |
+| name      | description                                             | type      | default | required |
+| --------- | ------------------------------------------------------- | --------- | ------- | -------- |
+| `value`   | Value to set the summary to                             | `integer` | null    | `true`   |
+| `options` | Object that can be used to specify labels and quantiles | `object`  | `{}`    | `false`  |
 
 _Example_
 
@@ -422,18 +425,19 @@ const summary = client.summary(options);
 
 summary.observe(0.001); // observe value 0.001
 summary.observe(5, { labels: { url: 'http://finn.no' } }); // observe value 5, specify labels
-summary.observe(0.01, {
-    meta: { quantiles: [0.001, 0.01, 0.5, 0.9, 0.99] }, // observe 0.01, use meta to specify quantile meta
-});
+summary.observe(
+    0.01,
+    { quantiles: [0.001, 0.01, 0.5, 0.9, 0.99] }, // observe 0.01, use meta to specify quantile meta
+);
 ```
 
 ##### summary.timer(options)
 
 Method that when called will return an end function for use in measuring the time between 2 points
 
-| name      | description                                        | type     | default | required |
-| --------- | -------------------------------------------------- | -------- | ------- | -------- |
-| `options` | Object that can be used to specify labels and meta | `object` | `{}`    | `false`  |
+| name      | description                                             | type     | default | required |
+| --------- | ------------------------------------------------------- | -------- | ------- | -------- |
+| `options` | Object that can be used to specify labels and quantiles | `object` | `{}`    | `false`  |
 
 _Examples_
 
@@ -458,9 +462,7 @@ end({ labels: { url: 'http://finn.no' } }); // set labels in end function
 ```
 
 ```js
-const end = summary.timer({
-    meta: { quantiles: [0.001, 0.01, 0.5, 0.9, 0.99] },
-}); // start timer, set meta
+const end = summary.timer({ quantiles: [0.001, 0.01, 0.5, 0.9, 0.99] }); // start timer, set meta
 // stuff happens
 end();
 ```
@@ -576,7 +578,7 @@ _Example_
 
 ```js
 const client = new Metrics();
-client.on('drop', metric => {
+client.on('drop', (metric) => {
     console.log('dropped metric', metric);
 });
 ```

--- a/client.d.ts
+++ b/client.d.ts
@@ -1,0 +1,136 @@
+import { EventEmitter } from 'events';
+import { Transform, TransformOptions } from 'readable-stream';
+import { MetricOptions } from '@metrics/metric';
+
+interface BaseMetricsOptions {
+    /**
+     * Valid characters: `a-zA-Z0-9_`
+     */
+    name: string;
+    description: string;
+    labels?: Record<string, string | number | boolean | null>;
+}
+
+export interface MetricsCounter extends EventEmitter {
+    /**
+     * Increment the counter
+     *
+     * @example <caption>Increment by 1</caption>
+     * counter.inc();
+     * @example <caption>Increment by 10</caption>
+     * counter.inc(10);
+     * @example <caption>Increment by 1 with labels</caption>
+     * counter.inc({ labels: { url: 'https://www.mysite.com' } });
+     * @example <caption>Increment by 10 with labels</caption>
+     * counter.inc(10, { labels: { url: 'https://www.mysite.com' } });
+     */
+    inc(
+        value?: number | BaseMetricsOptions,
+        options?: Pick<BaseMetricsOptions, 'labels'>,
+    ): void;
+}
+
+export interface MetricsGauge extends EventEmitter {
+    set(value: number, options?: Pick<BaseMetricsOptions, 'labels'>): void;
+}
+
+export interface MetricsHistogramOptions extends BaseMetricsOptions {
+    buckets?: number[];
+}
+
+export type EndTimer = (options?: Pick<BaseMetricsOptions, 'labels'>) => void;
+
+export interface MetricsHistogram extends EventEmitter {
+    /**
+     * When called, will popupale the metrics stream with a histogram value.
+     *
+     * @param value
+     * @param options
+     */
+    observe(
+        value: number,
+        options?: Pick<MetricsHistogramOptions, 'labels' | 'buckets'>,
+    ): void;
+    /**
+     *  Measure time between two points.
+     *
+     * @example <caption>Measure time between two points</caption>
+     * const end = histogram.timer();
+     * // some stuff happens
+     * end();
+     * @example <caption>Measure time between two points with labels</caption>
+     * const end = histogram.timer({ labels: { url: 'https://www.mysite.com' } });
+     * // some stuff happens
+     * end();
+     * @example <caption>Measure time between two points with labels in the end function</caption>
+     * const end = histogram.timer();
+     * // some stuff happens
+     * end({ labels: { url: 'https://www.mysite.com' } });
+     * @example <caption>Set custom buckets</caption>
+     * const end = histogram.timer({ buckets: [0.1, 0.5, 1, 2, 5] });
+     * // some stuff happens
+     * end();
+     */
+    timer(
+        options?: Pick<MetricsHistogramOptions, 'labels' | 'buckets'>,
+    ): EndTimer;
+}
+
+export interface MetricsSummaryOptions extends BaseMetricsOptions {
+    quantiles?: number[];
+}
+
+export interface MetricsSummary extends EventEmitter {
+    /**
+     * When called, will popupale the metrics stream with a histogram value.
+     *
+     * @param value
+     * @param options
+     */
+    observe(
+        value: number,
+        options?: Pick<MetricsSummaryOptions, 'labels' | 'quantiles'>,
+    ): void;
+    /**
+     *  Measure time between two points.
+     *
+     * @example <caption>Measure time between two points</caption>
+     * const end = summary.timer();
+     * // some stuff happens
+     * end();
+     * @example <caption>Measure time between two points with labels</caption>
+     * const end = summary.timer({ labels: { url: 'https://www.mysite.com' } });
+     * // some stuff happens
+     * end();
+     * @example <caption>Measure time between two points with labels in the end function</caption>
+     * const end = summary.timer();
+     * // some stuff happens
+     * end({ labels: { url: 'https://www.mysite.com' } });
+     * @example <caption>Set custom buckets</caption>
+     * const end = summary.timer({ quantiles: [0.001, 0.01, 0.5, 0.9, 0.99] });
+     * // some stuff happens
+     * end();
+     */
+    timer(
+        options?: Pick<MetricsSummaryOptions, 'labels' | 'quantiles'>,
+    ): EndTimer;
+}
+
+export interface MetricsClientOptions extends TransformOptions {
+    /**
+     * An optional unique identifier of the MetricsClient instance.
+     * A random ID will be generated if not provided.
+     */
+    id?: string;
+}
+
+export default class MetricsClient extends Transform {
+    constructor(options?: MetricsClientOptions);
+
+    counter(options: BaseMetricsOptions): MetricsCounter;
+    gauge(options: BaseMetricsOptions): MetricsGauge;
+    histogram(options: MetricsHistogramOptions): MetricsHistogram;
+    summary(options: BaseMetricsOptions): MetricsHistogram;
+    metric(options: MetricOptions): void;
+    timer(options: MetricOptions): (options?: Partial<MetricOptions>) => void;
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@metrics/client",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A streaming metric producer. Allows producing counters, gauges, histograms and summaries in a way that is independent of your metrics system.",
   "main": "lib/client.js",
+  "types": "client.d.ts",
   "files": [
-    "lib"
+    "lib",
+    "client.d.ts"
   ],
   "scripts": {
     "bench": "node benchmark/benchmark.js",


### PR DESCRIPTION
## Description

- Remove `meta` wrapper from options and examples in the README, for stuff that no longer has them
- Add type definition for the client

## Todos

- [x] Tests (N/A)
- [x] Documentation

## Related PRs
* https://github.com/metrics-js/metric/pull/35