### PR TITLE
fix: indicate the new minimum dependency, for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "monitoring"
   ],
   "dependencies": {
-    "@metrics/metric": "^2.3.1",
+    "@metrics/metric": "^2.3.2",
     "readable-stream": "^3.4.0",
     "time-span": "^4.0.0"
   },


### PR DESCRIPTION
`^2.3.1` _should_ give folks the latest version, but bump the minimum in case it doesn't