### PR TITLE
fix: correct the BaseMetricsOptions value for inc

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -45,7 +45,7 @@ declare namespace MetricsClient {
          * counter.inc(10, { labels: { url: 'https://www.mysite.com' } });
          */
         inc(
-            value?: number | BaseMetricsOptions,
+            value?: number | Pick<BaseMetricsOptions, 'labels'>,
             options?: Pick<BaseMetricsOptions, 'labels'>,
         ): void;
     }


### PR DESCRIPTION
Matches the third example in JSDoc

```
* @example <caption>Increment by 1 with labels</caption>
* counter.inc({ labels: { url: 'https://www.mysite.com' } });
```