### PR TITLE
fix: include types/readable-stream as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "@metrics/metric": "^2.3.2",
+    "@types/readable-stream": "^4.0.0",
     "readable-stream": "^3.4.0",
     "time-span": "^4.0.0"
   },


### PR DESCRIPTION
The type definitions for the Metrics client are incomplete without this dependency, and the fix is hard to identify from the error messages. This is technically not a runtime dependency, and affects only a subset of our users, but this makes the module much easier to consume as TypeScript and/or JSDoc typechecking users.

See for instance https://github.com/podium-lib/http-client/pull/14